### PR TITLE
Fix a Lua error with the scoreboard's new feature

### DIFF
--- a/gamemodes/fnafgm/gamemode/cl_scoreboard.lua
+++ b/gamemodes/fnafgm/gamemode/cl_scoreboard.lua
@@ -191,9 +191,9 @@ local PLAYER_LINE = {
 			end
 
 			self.Mute.PaintOver = function(s, w, h)
-				if ( !IsValid( self.Player ) ) then return end
+				if not IsValid(self.Player) then return end
 				local a = 255 - math.Clamp(CurTime() - (s.LastTick or 0), 0, 3) * 255
-				if ( a <= 0 ) then return end
+				if a <= 0 then return end
 				draw.RoundedBox(4, 0, 0, w, h, Color(0, 0, 0, a * 0.75))
 				draw.SimpleText(math.ceil(self.Player:GetVoiceVolumeScale() * 100) .. "%", "DermaDefaultBold", w / 2, h / 2, Color(255, 255, 255, a), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 			end

--- a/gamemodes/fnafgm/gamemode/cl_scoreboard.lua
+++ b/gamemodes/fnafgm/gamemode/cl_scoreboard.lua
@@ -191,7 +191,9 @@ local PLAYER_LINE = {
 			end
 
 			self.Mute.PaintOver = function(s, w, h)
+				if ( !IsValid( self.Player ) ) then return end
 				local a = 255 - math.Clamp(CurTime() - (s.LastTick or 0), 0, 3) * 255
+				if ( a <= 0 ) then return end
 				draw.RoundedBox(4, 0, 0, w, h, Color(0, 0, 0, a * 0.75))
 				draw.SimpleText(math.ceil(self.Player:GetVoiceVolumeScale() * 100) .. "%", "DermaDefaultBold", w / 2, h / 2, Color(255, 255, 255, a), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 			end


### PR DESCRIPTION
When a player connect and leave and that another player open the TAB menu, this error appear. This PR fix the error.

```
[Five Nights at Freddy's Gamemode] gamemodes/fnafgm/gamemode/cl_scoreboard.lua:196: Tried to use a NULL entity!
  1. GetVoiceVolumeScale - [C]:-1
   2. unknown - gamemodes/fnafgm/gamemode/cl_scoreboard.lua:196
```